### PR TITLE
Changed calculation of related position price for cart/cart/index tab…

### DIFF
--- a/src/ShoppingCart.php
+++ b/src/ShoppingCart.php
@@ -11,7 +11,6 @@
 
 namespace hiqdev\yii2\cart;
 
-use hipanel\modules\finance\cart\AbstractCartPosition;
 use hiqdev\yii2\cart\behaviors\EnsureDeleteRelatedPosition;
 use Yii;
 use yii\base\Event;
@@ -19,12 +18,12 @@ use yz\shoppingcart\CartActionEvent;
 
 /**
  * Class ShoppingCart.
- * @property AbstractCartPosition[] $positions
+ * @property CartPositionInterface[] $positions
  */
 class ShoppingCart extends \yz\shoppingcart\ShoppingCart
 {
     /**
-     * @var AbstractCartPosition[]
+     * @var CartPositionInterface[]
      * TODO make local AbstractCartPosition
      */
     protected $_positions = [];

--- a/src/controllers/CartController.php
+++ b/src/controllers/CartController.php
@@ -44,7 +44,7 @@ class CartController extends Controller implements ViewContextInterface
         ]);
 
         if (Yii::$app->request->isAjax) {
-            return $this->renderPartial('index', [
+            return $this->renderAjax('index', [
                 'cart' => $cart,
                 'module' => $this->module,
                 'dataProvider' => $dataProvider,

--- a/src/views/cart/index.php
+++ b/src/views/cart/index.php
@@ -78,12 +78,13 @@ $this->params['breadcrumbs'][] = $this->title;
                         'format' => 'raw',
                         'label' => Yii::t('cart', 'Price'),
                         'contentOptions' => ['style' => 'vertical-align: middle;white-space: nowrap;'],
-                        'value' => static function ($position) use ($cart): string {
+                        'value' => static function (CartPositionInterface $position) use ($cart): string {
                             $price = $cart->formatCurrency($position->cost, $position->currency);
-                            if ($relatedPostion = $cart->findRelatedFor($position)) {
+                            if ($relatedPosition = $cart->findRelatedFor($position)) {
+                                $relatedPosition->setQuantity($position->getQuantity());
                                 $price .= sprintf(
                                     '&nbsp;<span class="text-success text-bold">+ %s</span>',
-                                    $cart->formatCurrency($relatedPostion->cost, $relatedPostion->currency)
+                                    $cart->formatCurrency($relatedPosition->getCost(false), $relatedPosition->currency)
                                 );
                             }
 


### PR DESCRIPTION
…le, use `ShoppingCart::getConst(false)` to get `quantity` * `price` but not just `value`